### PR TITLE
Vaciar campos de texto después de crear una raza

### DIFF
--- a/components/animal-breed-modal.tsx
+++ b/components/animal-breed-modal.tsx
@@ -83,6 +83,8 @@ export default function AnimalBreedModal({
     } catch (error) {
       console.error("Error al guardar la raza", error);
     } finally {
+      setBreedName("");
+      setAnimalType("");
       setIsLoading(false); // Desbloquear botón después de la petición
     }
   };


### PR DESCRIPTION
El formulario se abre sin datos precargados para que el usuario pueda ingresar información