### PR TITLE
agregue un modal para aceptar auspiciante

### DIFF
--- a/components/form/modal.tsx
+++ b/components/form/modal.tsx
@@ -44,7 +44,7 @@ useEffect(() => {
               type="button"
               variant={confirmVariant}
               size="md"
-              className="rounded hover:bg-red-900"
+              className={`rounded ${confirmVariant === "cta" ? "hover:bg-green-700" : "hover:bg-red-900"}`}
               onClick={onConfirm}
             >
               {textConfirm}


### PR DESCRIPTION
Un nuevo modal para confirmar auspiciante, use el componente ConfirmationModal
className={`rounded ${confirmVariant === "cta" ? "hover:bg-green-700" : "hover:bg-red-900"}`} este cambio es para poner en verde tambien el boton de confirmar cuando la variante es cta ya que quedaba más acorde al querer aceptar algo.