### PR TITLE
Adoptamena 473 fe actualizar el componete de mapa para mostrar el radio de ubicacion

### DIFF
--- a/app/(pages)/(content)/profile/[id]/page.tsx
+++ b/app/(pages)/(content)/profile/[id]/page.tsx
@@ -235,7 +235,7 @@ export default function ProfilePage() {
                     {/* Mostrar el mapa si las coordenadas están disponibles */}
                     {userProfile?.addressCoordinates && (
                         <div className='w-[40vw] mt-[-70px] '>
-                            <PostLocationMap location={userProfile?.addressCoordinates} />
+                            <PostLocationMap location={userProfile?.addressCoordinates} isPreciseLocation={isOrganization}/>
                         </div>
                     )}
 

--- a/components/post/post-content.tsx
+++ b/components/post/post-content.tsx
@@ -3,7 +3,7 @@ import PostComments from "@/components/post/post-comments";
 import { Post } from "@/types/post";
 import { useAuth } from "@/contexts/auth-context";
 import { Pet } from "@/types/pet";
-import { POST_TYPEID } from "@/types/constants";
+import { POST_TYPEID, PET_STATUS } from "@/types/constants";
 
 interface PostContentProps {
     post?: Post | null;
@@ -14,6 +14,7 @@ const PostContent = ({ post, pet }: PostContentProps) => {
     const { user, loading: userLoading, authToken } = useAuth();
     const isPost = !!post;
     const isPreciseLocation = post?.postType.id === POST_TYPEID.VOLUNTEERING;
+    const isAdoption = pet?.petStatus?.id === PET_STATUS.ADOPTION
 
     return (
         <section>
@@ -23,7 +24,7 @@ const PostContent = ({ post, pet }: PostContentProps) => {
                 </p>
             </div>
 
-            <PostLocationMap location={post?.locationCoordinates || pet?.addressCoordinates} isPreciseLocation={isPreciseLocation}/>
+            <PostLocationMap location={post?.locationCoordinates || pet?.addressCoordinates} isPreciseLocation={isPreciseLocation || isAdoption}/>
             <PostComments authToken={authToken ?? undefined} user={user} userLoading={userLoading} referenceId={isPost ? post?.id : pet?.id as number} referenceType={isPost ? "POST" : "PET"} />
         </section>
     );

--- a/components/post/post-content.tsx
+++ b/components/post/post-content.tsx
@@ -3,6 +3,7 @@ import PostComments from "@/components/post/post-comments";
 import { Post } from "@/types/post";
 import { useAuth } from "@/contexts/auth-context";
 import { Pet } from "@/types/pet";
+import { POST_TYPEID } from "@/types/constants";
 
 interface PostContentProps {
     post?: Post | null;
@@ -12,6 +13,7 @@ interface PostContentProps {
 const PostContent = ({ post, pet }: PostContentProps) => {
     const { user, loading: userLoading, authToken } = useAuth();
     const isPost = !!post;
+    const isPreciseLocation = post?.postType.id === POST_TYPEID.VOLUNTEERING;
 
     return (
         <section>
@@ -21,7 +23,7 @@ const PostContent = ({ post, pet }: PostContentProps) => {
                 </p>
             </div>
 
-            <PostLocationMap location={post?.locationCoordinates || pet?.addressCoordinates} />
+            <PostLocationMap location={post?.locationCoordinates || pet?.addressCoordinates} isPreciseLocation={isPreciseLocation}/>
             <PostComments authToken={authToken ?? undefined} user={user} userLoading={userLoading} referenceId={isPost ? post?.id : pet?.id as number} referenceType={isPost ? "POST" : "PET"} />
         </section>
     );

--- a/components/post/post-location-map.tsx
+++ b/components/post/post-location-map.tsx
@@ -11,9 +11,10 @@ const MapWithNoSSR = dynamic(
 
 interface PostLocationMapProps {
     location?: string;
+    isPreciseLocation?: boolean;
 }
 
-const PostLocationMap = ({ location }: PostLocationMapProps) => {
+const PostLocationMap = ({ location, isPreciseLocation: precisedLocation = false }: PostLocationMapProps) => {
     const coordinates = location?.split(',').map(coord => parseFloat(coord.trim())) ?? [];
 
     const validCoordinates = coordinates.length === 2 &&
@@ -26,7 +27,7 @@ const PostLocationMap = ({ location }: PostLocationMapProps) => {
                 Ubicación
             </h2>
             {validCoordinates ?
-                <MapWithNoSSR location={[coordinates[0], coordinates[1]] as [number, number]} /> :
+                <MapWithNoSSR location={[coordinates[0], coordinates[1]] as [number, number]} precisionMarker={precisedLocation} /> :
                 <p className="text-2xl text-gray-700 mt-8">
                     No se ha proporcionado una ubicación.
                 </p>}

--- a/components/post/post-map.tsx
+++ b/components/post/post-map.tsx
@@ -43,7 +43,6 @@ export default function PostMap({ location, precisionMarker = false }: PostMapPr
                     attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
                     url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
                 />
-                <Marker position={location} icon={customIcon} />
                 {precisionMarker ?
                     (
                         <Marker position={location} icon={customIcon} />

--- a/components/post/post-map.tsx
+++ b/components/post/post-map.tsx
@@ -1,14 +1,23 @@
 "use client";
 
-import { MapContainer, TileLayer, Marker } from 'react-leaflet';
+import { MapContainer, TileLayer, Marker, Circle } from 'react-leaflet';
 import { Icon } from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 
 interface PostMapProps {
     location: [number, number];
+    precisionMarker?: boolean;
+}
+//funcion para despalzar la ubicacion (max 300 metros)
+function getRandomOffset(maxOffset = 0.003): [number, number] {
+    const latOffset = (Math.random() - 0.5) * 2 * maxOffset;
+    const lngOffset = (Math.random() - 0.5) * 2 * maxOffset;
+    return [latOffset, lngOffset];
 }
 
-export default function PostMap({ location }: PostMapProps) {
+
+
+export default function PostMap({ location, precisionMarker = false }: PostMapProps) {
     const customIcon = new Icon({
         iconUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png',
         iconSize: [25, 41],
@@ -17,6 +26,11 @@ export default function PostMap({ location }: PostMapProps) {
         shadowUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png',
         shadowSize: [41, 41],
     });
+    const [latOffset, lngOffset] = getRandomOffset();
+    const displacedLocation: [number, number] = [
+        location[0] + latOffset,
+        location[1] + lngOffset,
+    ];
 
     return (
         <div className="relative h-[40vh] rounded-3xl overflow-hidden border z-10">
@@ -30,6 +44,10 @@ export default function PostMap({ location }: PostMapProps) {
                     url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
                 />
                 <Marker position={location} icon={customIcon} />
+                {precisionMarker ?
+                    (
+                        <Marker position={location} icon={customIcon} />
+                    ) : (<Circle center={displacedLocation} radius={2000} />)}
             </MapContainer>
         </div>
     );


### PR DESCRIPTION
# Radio de ubicacion
- Se implemento para mostrar area circular de la ubicacion con un radio de 3 Km
- El centro del circulo se desplaza maximo 300 metros cada vez que se renderiza el componente del mapa
- La ubicacion precisa esta disponible para las mascotas de tipo adopcion, publicaciones del tipo voluntariado y perfiles de organizaciones, caso contrario se muestra el area circular con centro desplazado
[ticket](https://projectliderfiuni2025.atlassian.net/browse/ADOPTAMENA-473?atlOrigin=eyJpIjoiN2ZhMTc0MmEyMGM2NGE3N2JlODQ0YTBiZjA0NmM1YTIiLCJwIjoiaiJ9)