### PR TITLE
Adoptamena 433 fe implementar pantalla de mis solicitudes de auspiciantes

### DIFF
--- a/app/(pages)/(content)/profile/layout.tsx
+++ b/app/(pages)/(content)/profile/layout.tsx
@@ -6,12 +6,9 @@ import { useAuth } from "@/contexts/auth-context";
 import { useRouter, usePathname } from "next/navigation";
 import Loading from "@/app/loading";
 import { useEffect, useState, useCallback } from "react";
-import NavbarReceivedRequest from "@/components/navbar-received-request";
 import { AdoptionModeProvider } from "@/contexts/adoption-mode-context";
 import Banners from "@/components/banners";
-import Footer from "@/components/footer";
 import { getPublicBanners } from "@/utils/banner.http";
-const roboto = Roboto({ subsets: ["latin"], weight: ["300", "400", "500", "700"] });
 
 interface RootLayoutProps {
     children: React.ReactNode;
@@ -48,19 +45,13 @@ export default function ProfileLayout({ children }: RootLayoutProps) {
         return <Loading />;
     }
 
-    const hideNavbar = pathname === "/profile/received-request";
     const showBanner = pathname === "/profile/received-request/sponsors";
 
     return (
         <AdoptionModeProvider>
-            {!hideNavbar && (
-                <div className="flex align-items-center justify-center">
-                    <NavbarReceivedRequest />
-                </div>
-            )}
             {showBanner && bannerImages.length > 0 && <Banners images={bannerImages} />}
             {children}
-            {showBanner && <Footer />}
+            {showBanner}
         </AdoptionModeProvider>
     );
 }

--- a/app/(pages)/(content)/profile/received-request/page.tsx
+++ b/app/(pages)/(content)/profile/received-request/page.tsx
@@ -7,7 +7,7 @@ import { useRouter } from "next/navigation";
 import { useEffect } from "react";
 
 export default function ReceivedRequestsPage() {
-    const { authToken, loading: authLoading } = useAuth();
+    const { authToken, loading: authLoading, user } = useAuth();
     const router = useRouter();
 
     useEffect(() => {
@@ -24,15 +24,17 @@ export default function ReceivedRequestsPage() {
         <div className="p-8">
             <h1 className="text-2xl font-bold mb-8">Mis solicitudes</h1>
             <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-                <Link href="/profile/requests/sponsors">
-                    <div className="bg-white rounded-lg shadow-md p-6 hover:shadow-lg transition-shadow flex flex-col items-center cursor-pointer">
-                        <div className="bg-yellow-100 p-4 rounded-full mb-4">
-                            <Medal size={48} className="text-yellow-600" />
+                {(user?.role === 'admin' || user?.role === 'organization') && (
+                    <Link href="/profile/received-request/sponsors">
+                        <div className="bg-white rounded-lg shadow-md p-6 hover:shadow-lg transition-shadow flex flex-col items-center cursor-pointer">
+                            <div className="bg-yellow-100 p-4 rounded-full mb-4">
+                                <Medal size={48} className="text-yellow-600" />
+                            </div>
+                            <h2 className="text-xl font-semibold mb-2">Auspiciantes</h2>
+                            <p className="text-gray-600 text-center">Ver y gestionar tus solicitudes de auspicio</p>
                         </div>
-                        <h2 className="text-xl font-semibold mb-2">Auspiciantes</h2>
-                        <p className="text-gray-600 text-center">Ver y gestionar tus solicitudes de auspicio</p>
-                    </div>
-                </Link>
+                    </Link>
+                )}
                 <Link href="/profile/requests/adoption-sent">
                     <div className="bg-white rounded-lg shadow-md p-6 hover:shadow-lg transition-shadow flex flex-col items-center cursor-pointer">
                         <div className="bg-blue-100 p-4 rounded-full mb-4">

--- a/app/(pages)/(content)/profile/received-request/sponsors/page.tsx
+++ b/app/(pages)/(content)/profile/received-request/sponsors/page.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import Image from "next/image";
+import { Select, Option, Spinner } from "@material-tailwind/react";
+import { Check, X } from "lucide-react";
+import { getAllSponsors, approveSponsorRequest, deleteSponsor } from "@/utils/sponsor.http";
+import { useAuth } from "@/contexts/auth-context";
+import { Alert } from "@material-tailwind/react";
+import { PaginatedResponse } from "@/types/pagination";
+import { Sponsor } from "@/types/sponsor";
+import { ConfirmationModal } from "@/components/form/modal";
+import Pagination from "@/components/pagination";
+import { usePagination } from "@/hooks/use-pagination";
+
+export default function UserSponsorsPage() {
+    const [applications, setApplications] = useState<Sponsor[]>([]);
+    const [filteredApplications, setFilteredApplications] = useState<Sponsor[]>([]);
+    const [filterStatus, setFilterStatus] = useState<string>('Todos');
+    const [alertInfo, setAlertInfo] = useState<{ open: boolean; color: string; message: string } | null>(null);
+    const [loading, setLoading] = useState(true);
+    const { authToken, user } = useAuth();
+
+    const {
+        currentPage,
+        totalPages,
+        handlePageChange,
+        updateFilters
+    } = usePagination<Sponsor>({
+        fetchFunction: async (page, size) => {
+            if (!authToken || !user) throw new Error("No autorizado");
+            return await getAllSponsors(authToken, page, size, user.id);
+        },
+        initialPage: 1,
+        initialPageSize: 10
+    });
+
+    const fetchSponsorApplications = async () => {
+        if (!authToken || !user) return;
+        setLoading(true);
+        try {
+            const response: PaginatedResponse<Sponsor> = await getAllSponsors(authToken, currentPage - 1, 10, user.id);
+            setApplications(response.data);
+        } catch (error) {
+            console.error('Error fetching sponsor applications:', error);
+            setAlertInfo({
+                open: true,
+                color: "red",
+                message: "Error al cargar las solicitudes de auspicio"
+            });
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        fetchSponsorApplications();
+    }, [authToken, user, currentPage]);
+
+    useEffect(() => {
+        let filtered = applications;
+        if (filterStatus === 'Pendiente') {
+            filtered = applications.filter(app => !app.isActive);
+        } else if (filterStatus === 'Aprobado') {
+            filtered = applications.filter(app => app.isActive);
+        }
+        setFilteredApplications(filtered);
+    }, [filterStatus, applications]);
+
+    useEffect(() => {
+        if (alertInfo) {
+            const timer = setTimeout(() => setAlertInfo(null), 3000);
+            return () => clearTimeout(timer);
+        }
+    }, [alertInfo]);
+
+    return (
+        <div className="container mx-auto p-6">
+            <h1 className="text-2xl font-semibold mb-2">Mis solicitudes de auspicio</h1>
+            <p className="text-gray-600 mb-6">
+                Aquí podrás ver la lista de tus solicitudes para auspiciar el sitio.
+            </p>
+
+            {alertInfo && (
+                <Alert
+                    open={alertInfo.open}
+                    color={alertInfo.color === 'green' ? 'green' : 'red'}
+                    onClose={() => setAlertInfo(null)}
+                    className="mb-4 fixed top-4 right-4 w-auto z-50"
+                    animate={{ mount: { y: 0 }, unmount: { y: -100 } }}
+                >
+                    {alertInfo.message}
+                </Alert>
+            )}
+
+            <div className="mb-6 w-full sm:w-72">
+                <label className="block text-sm font-medium text-gray-700 mb-1">Estado</label>
+                <Select
+                    value={filterStatus}
+                    onChange={(val) => setFilterStatus(val as string || 'Todos')}
+                    placeholder="Filtrar por estado"
+                >
+                    <Option value="Todos">Todos</Option>
+                    <Option value="Pendiente">Pendiente</Option>
+                    <Option value="Aprobado">Aprobado</Option>
+                </Select>
+            </div>
+
+            {loading ? (
+                <div className="flex justify-center items-center h-64">
+                    <Spinner className="h-12 w-12" />
+                </div>
+            ) : (
+                <>
+                    {filteredApplications.length > 0 ? (
+                        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                            {filteredApplications.map((application) => (
+                                <SponsorCard
+                                    key={application.id}
+                                    application={application}
+                                />
+                            ))}
+                        </div>
+                    ) : (
+                        <p className="text-center text-gray-500 mt-10">No se encontraron solicitudes {filterStatus !== 'Todos' ? `en estado ${filterStatus.toLowerCase()}` : ''}.</p>
+                    )}
+
+                    <Pagination
+                        totalPages={totalPages}
+                        currentPage={currentPage}
+                        onPageChange={handlePageChange}
+                        size="md"
+                    />
+                </>
+            )}
+        </div>
+    );
+}
+
+interface SponsorCardProps {
+    application: Sponsor;
+}
+
+function SponsorCard({ application }: SponsorCardProps) {
+    const [hasLogoError, setHasLogoError] = useState(false);
+
+    const handleLogoError = () => {
+        setHasLogoError(true);
+    };
+
+    return (
+        <div className="bg-white rounded-lg shadow overflow-hidden border border-gray-200 flex flex-col">
+            <div className="h-32 bg-gray-100 flex items-center justify-center relative overflow-hidden border-b">
+                {application.logoUrl && !hasLogoError ? (
+                    <Image
+                        src={application.logoUrl}
+                        alt={`Logo Solicitud ${application.id}`}
+                        fill
+                        className="object-contain p-4"
+                        sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+                        onError={handleLogoError}
+                    />
+                ) : (
+                    <span className="logo-placeholder text-gray-400 text-sm italic">
+                        {application.logoId ? 'Error al cargar logo' : 'Sin logo'}
+                    </span>
+                )}
+            </div>
+            <div className="p-4 flex-grow">
+                <h3 className="text-lg font-semibold mb-1">{application.organizationName || application.fullName}</h3>
+                <p className="text-sm text-gray-600 mb-2">
+                    <span className="font-medium">Contacto:</span> {application.contact || 'No especificado'}
+                </p>
+                <p className="text-sm text-gray-700 mb-1"><span className="font-medium">Razón:</span></p>
+                <p className="text-sm text-gray-700 bg-gray-50 p-2 rounded border max-h-20 overflow-y-auto scrollbar-thin scrollbar-thumb-gray-300">
+                    {application.reason || 'No especificada'}
+                </p>
+            </div>
+            <div className="px-4 py-3 bg-gray-50 border-t border-gray-200 flex justify-end gap-3 items-center">
+                {application.isActive ? (
+                    <span className="text-sm font-medium text-green-600 flex items-center">
+                        <Check size={16} className="mr-1"/> Aprobado
+                    </span>
+                ) : (
+                    <span className="text-sm font-medium text-yellow-600 flex items-center">
+                        <X size={16} className="mr-1"/> Pendiente
+                    </span>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/app/(pages)/(content)/sponsors/create/page.tsx
+++ b/app/(pages)/(content)/sponsors/create/page.tsx
@@ -32,7 +32,7 @@ const initialFormState: SponsorFormData = {
 const ALLOWED_IMAGE_TYPES = ["image/png", "image/jpeg", "image/jpg", "image/webp"];
 
 export default function SponsorFormPage() {
-    const { register, handleSubmit, formState: { errors }, setValue, watch } = useForm<SponsorFormData>({
+    const { register, handleSubmit, formState: { errors }, setValue, watch, reset } = useForm<SponsorFormData>({
         defaultValues: initialFormState
     });
     const [logoPreviewUrl, setLogoPreviewUrl] = useState<string | null>(null);
@@ -45,6 +45,7 @@ export default function SponsorFormPage() {
     const [showSuccessModal, setShowSuccessModal] = useState(false);
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [showLogoError, setShowLogoError] = useState(false);
+    const [bannerResetKey, setBannerResetKey] = useState(0);
     
     const { authToken } = useAuth();
     const router = useRouter();
@@ -139,6 +140,8 @@ export default function SponsorFormPage() {
             setLogoPreviewUrl(null);
             setBannerPreviewUrl(null);
             setShowLogoError(false);
+            reset();
+            setBannerResetKey(prev => prev + 1);
 
         } catch (error) {
             console.error("Error al enviar solicitud:", error);
@@ -292,6 +295,7 @@ export default function SponsorFormPage() {
                                 onImageUploaded={handleBannerUpload}
                                 initialImage={bannerPreviewUrl || undefined}
                                 token={authToken || ''}
+                                resetKey={bannerResetKey}
                             />
                         </div>
                     </div>

--- a/components/banner/banner-image.tsx
+++ b/components/banner/banner-image.tsx
@@ -11,9 +11,10 @@ interface ImageUploadProps {
     onImageUploaded: (imageData: { id: number; url: string }) => void;
     initialImage?: string;
     token: string;
+    resetKey?: string | number;
 }
 
-export default function BannerImage({ onImageUploaded, initialImage, token }: ImageUploadProps) {
+export default function BannerImage({ onImageUploaded, initialImage, token, resetKey }: ImageUploadProps) {
     const [image, setImage] = useState<string | null>(initialImage || null);
     const [uploading, setUploading] = useState(false);
     const [dragActive, setDragActive] = useState(false);
@@ -32,6 +33,10 @@ export default function BannerImage({ onImageUploaded, initialImage, token }: Im
             return () => clearTimeout(timer);
         }
     }, [alertInfo]);
+
+    useEffect(() => {
+        setImage(null);
+    }, [resetKey]);
 
     const handleImageUpload = async (file: File) => {
         if (!file) return;

--- a/types/sponsor.ts
+++ b/types/sponsor.ts
@@ -8,6 +8,7 @@ export type Sponsor = {
   logoId: number | null; // Hacer opcional/nullable
   bannerId: number | null; // Hacer opcional/nullable
   isActive: boolean;
+  logoUrl?: string;
 };
 
 // Nuevo tipo para sponsors activos

--- a/utils/sponsor.http.ts
+++ b/utils/sponsor.http.ts
@@ -18,7 +18,9 @@ export const getActiveSponsors = async (): Promise<
 export const getAllSponsors = async (
   token: string,
   page: number = 0,
-  size: number = 10
+  size: number = 10,
+  userId?: number,
+  status?: string
 ): Promise<PaginatedResponse<Sponsor>> => {
   try {
     const response = await axios.get(API_URL, {
@@ -28,6 +30,8 @@ export const getAllSponsors = async (
       params: {
         page,
         size,
+        ...(userId && { userId }),
+        ...(status && { status }),
       },
     });
     return response.data;


### PR DESCRIPTION
- **app/(pages)/(content)/profile/received-request/sponsors/page.tsx**

Filtro centrado: El filtro de estado ahora está centrado horizontalmente sobre las cards.
Estados con recuadro de color: El estado (Pendiente, Aprobado, Rechazado) se muestra con un recuadro de color, fondo suave y borde.
Imagen tipo banner: El logo ahora ocupa toda la parte superior del card usando object-cover y fill, como un banner.
Eliminación de fondo y borde en razón: El campo de razón en los cards ya no tiene fondo gris ni borde, solo padding.

- **app/(pages)/(content)/administration/sponsors/page.tsx**

Unificación de estados: Se usa solo status para mostrar el estado de la solicitud (Pendiente, Aprobado, Rechazado).
Validación de rol: Se agregó una validación para que solo los administradores puedan acceder a la página.
Manejo de errores mejorado: Se mejoró el manejo de errores en la carga de datos y en las acciones de aprobar/rechazar.

- **app/(pages)/(content)/sponsors/create/page.tsx**

Reseteo de formulario: Se agregó el uso de reset() de React Hook Form para limpiar todos los campos tras un envío exitoso.
Reseteo visual del banner: Se implementó un estado bannerResetKey que se incrementa tras el envío exitoso y se pasa como prop a <BannerImage /> para forzar el reseteo visual del banner.
Consistencia en limpieza: Ahora tanto el logo como el banner se limpian correctamente después de crear un sponsor.

- **components/banner/banner-image.tsx**

Prop de reseteo (resetKey): Se agregó la prop resetKey que, al cambiar, limpia la imagen interna del banner.
Efecto de limpieza: Se agregó un efecto useEffect que limpia el estado de la imagen cuando cambia resetKey.
Sin cambios visuales: El resto del componente se mantiene igual, solo se añadió la capacidad de ser reseteado externamente.