### PR TITLE
solucion al bug de resetear contraseña

### DIFF
--- a/app/(pages)/auth/reset-password-request/page.tsx
+++ b/app/(pages)/auth/reset-password-request/page.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { useAuth } from "@/contexts/auth-context";
 import Loading from "@/app/loading";
 import { requestPasswordReset } from "@/utils/auth.http";
+import { Loader2Icon } from "lucide-react";
 
 export default function ResetPassword() {
   const [credentials, setCredentials] = useState({ email: "" });
@@ -20,22 +21,18 @@ export default function ResetPassword() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    setIsSubmitting(true);
+    setError("");
+    setMessage("");
 
     try {
-      const response = await requestPasswordReset({ email: credentials.email });
-      console.log("Recuperar contraseña para:", credentials.email);
-      console.log("Console responde: " + response.data)
-
-
-      if (response) {
-        console.log("Console responde: " + response.data)
-        setMessage("Se ha enviado un correo para la recuperación de contraseña.");
-      }
+      await requestPasswordReset({ email: credentials.email });
+      setMessage("Se ha enviado un correo para la recuperación de contraseña.");
     } catch (err: any) {
-
-      setError(err.response?.data || "Ocurrió un error al procesar la solicitud.");
+      console.error("Error al solicitar restablecimiento:", err);
+      setError(err.message || "Ocurrió un error al procesar la solicitud.");
     } finally {
-      setIsSubmitting(false); // Volvemos a habilitar el botón después de procesar
+      setIsSubmitting(false);
     }
   };
 
@@ -90,10 +87,7 @@ export default function ResetPassword() {
             >
               {isSubmitting ? (
                 <div className="flex items-center justify-center">
-                  <svg className="animate-spin -ml-1 mr-2 h-4 w-4 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                  </svg>
+                  <Loader2Icon className="animate-spin -ml-1 mr-2 h-4 w-4 text-white" />
                   Procesando...
                 </div>
               ) : (

--- a/utils/auth.http.ts
+++ b/utils/auth.http.ts
@@ -82,11 +82,11 @@ export const checkToken = async (token: string): Promise<User> => {
 const BASE_PATH = "auth/reset-password-request";
 const BASE_PATH_PASSWORD = "auth/reset-password";
 
-export const requestPasswordReset = async (params: Record<string, any>) => {
+export const requestPasswordReset = async (params: { email: string }) => {
   try {
     const response = await axios.post(
-      `${API_URL}/reset-password-request`,
-      params,
+      `${API_URL}/reset-password-request?email=${encodeURIComponent(params.email)}`,
+      {},
       {
         headers: {
           "Content-Type": "application/json",
@@ -125,7 +125,8 @@ export const resetPassword = async (params: Record<string, any>) => {
   } catch (error) {
     if (axios.isAxiosError(error)) {
       const status = error.response?.status;
-      throw new AuthError("Error al restablecer la contraseña", status || 500);
+      const message = error.response?.data?.message || "Error al restablecer la contraseña";
+      throw new AuthError(message, status || 500);
     }
     if (error instanceof AuthError) {
       throw error;


### PR DESCRIPTION
El email se envía como query param en la URL, tal como lo espera el backend.
**Archivo: utils/auth.http.ts**
Se limpian los estados antes de cada envío y se muestra un mensaje claro de éxito o error.
**Archivo: app/(pages)/auth/reset-password-request/page.tsx**
Se usaba un SVG personalizado para el spinner de carga en el botón.
Ahora: Se utiliza el componente Loader2Icon de la librería lucide-react, igual que en otros formularios del proyecto.
**Archivo: app/(pages)/auth/reset-password-request/page.tsx**