### PR TITLE
Sc 295 support email

### DIFF
--- a/utils/email-support-config.ts
+++ b/utils/email-support-config.ts
@@ -1,0 +1,12 @@
+export const EMAIL_CONFIG = {
+    SUPPORT: {
+        ADDRESS: 'adoptamena@gmail.com',
+        SUBJECT: 'Soporte AdoptameNa',
+        BODY: 'Hola,\n\nMe gustaría contactar con soporte por el siguiente motivo:\n\n'
+    }
+} as const;
+
+export const getSupportEmailLink = () => {
+    const { ADDRESS, SUBJECT, BODY } = EMAIL_CONFIG.SUPPORT;
+    return `mailto:${ADDRESS}?subject=${encodeURIComponent(SUBJECT)}&body=${encodeURIComponent(BODY)}`;
+}; 

--- a/utils/footer-link.ts
+++ b/utils/footer-link.ts
@@ -1,10 +1,13 @@
 // links para el footer
 
+import { getSupportEmailLink } from "./email-support-config";
+
 export const footerSections = [
     {
       title: "Ayuda",
       links: [
-        { name: "Preguntas frecuentes", path: "/faq" }
+        { name: "Preguntas frecuentes", path: "/faq" },
+        { name: "Contactar con soporte", path: getSupportEmailLink() }
       ],
     },
     {


### PR DESCRIPTION
Agregué un link en la sección de ayuda del footer que abre el cliente de correos del usuario y precarga un correo con un mensaje y asunto predeterminado en el archivo de configuracion `utils/email-support-config.ts`

![Screenshot 2025-05-23 145338](https://github.com/user-attachments/assets/d4e5fe13-eefd-46fa-bf33-ea332f212ec3)
