### PR TITLE
hacer responsive el navbar y los botones de Administración

### DIFF
--- a/app/(pages)/(content)/administration/page.tsx
+++ b/app/(pages)/(content)/administration/page.tsx
@@ -30,143 +30,143 @@ export default function Page() {
 
     if (authLoading || !user || user.role !== "admin") {
         return <Loading />;
-    }    return (
-        <div className="p-8">
+    }
+    return (
+        <div className="max-w-7xl mx-auto p-4 sm:p-8">
             <div className="mb-8 text-center">
-                <h1 className="text-2xl font-bold mb-2">Panel de Administración</h1>
-                <p className="text-gray-600">Bienvenido, {user.fullName}. Selecciona una opción para gestionar la plataforma.</p>
+                <h1 className="text-2xl md:text-3xl font-bold mb-2">Panel de Administración</h1>
+                <p className="text-gray-600 text-base md:text-lg">Bienvenido, {user.fullName}. Selecciona una opción para gestionar la plataforma.</p>
             </div>
 
             {/* Sección de Gestión de Publicaciones */}
-            <div className="mb-10">
-                <h2 className="text-xl font-bold mb-4 flex items-center">
+            <section className="mb-10 bg-white/80 rounded-xl shadow p-4 md:p-6">
+                <h2 className="text-xl font-semibold mb-4 flex items-center border-b pb-2">
                     <Newspaper className="mr-2 h-6 w-6 text-blue-600" />
                     Gestión de Publicaciones
                 </h2>
-                <div className="flex flex-wrap gap-3">
+                <div className="flex flex-col sm:flex-row flex-wrap gap-3">
                     <Link href="/administration/posts">
-                        <button className="bg-cyan-600 hover:bg-cyan-700 text-white py-3 px-5 rounded-lg flex items-center">
+                        <button className="w-full sm:w-auto bg-cyan-600 hover:bg-cyan-700 text-white py-3 px-5 rounded-lg flex items-center">
                             <Newspaper className="mr-2 h-5 w-5" />
                             Administrar Publicaciones
                         </button>
                     </Link>
                     <Link href="/administration/deleted-posts">
-                        <button className="bg-cyan-100 hover:bg-cyan-200 text-cyan-800 py-3 px-5 rounded-lg flex items-center">
+                        <button className="w-full sm:w-auto bg-cyan-100 hover:bg-cyan-200 text-cyan-800 py-3 px-5 rounded-lg flex items-center">
                             <Trash2 className="mr-2 h-5 w-5" />
                             Publicaciones Eliminadas
                         </button>
                     </Link>
                 </div>
-            </div>
+            </section>
 
             {/* Sección de Reportes */}
-            <div className="mb-10">
-                <h2 className="text-xl font-bold mb-4 flex items-center">
+            <section className="mb-10 bg-white/80 rounded-xl shadow p-4 md:p-6">
+                <h2 className="text-xl font-semibold mb-4 flex items-center border-b pb-2">
                     <Flag className="mr-2 h-6 w-6 text-red-600" />
                     Reportes
                 </h2>
-                <div className="flex flex-wrap gap-3">
+                <div className="flex flex-col sm:flex-row flex-wrap gap-3">
                     <Link href="/administration/report/pets">
-                        <button className="bg-red-600 hover:bg-red-700 text-white py-3 px-5 rounded-lg flex items-center">
+                        <button className="w-full sm:w-auto bg-red-600 hover:bg-red-700 text-white py-3 px-5 rounded-lg flex items-center">
                             <Flag className="mr-2 h-5 w-5" />
                             Reportes de Mascotas
                         </button>
                     </Link>
                     <Link href="/administration/report/posts">
-                        <button className="bg-red-100 hover:bg-red-200 text-red-800 py-3 px-5 rounded-lg flex items-center">
+                        <button className="w-full sm:w-auto bg-red-100 hover:bg-red-200 text-red-800 py-3 px-5 rounded-lg flex items-center">
                             <Flag className="mr-2 h-5 w-5" />
                             Reportes de Publicaciones
                         </button>
                     </Link>
                     <Link href="/administration/report/products">
-                        <button className="bg-red-100 hover:bg-red-200 text-red-800 py-3 px-5 rounded-lg flex items-center">
+                        <button className="w-full sm:w-auto bg-red-100 hover:bg-red-200 text-red-800 py-3 px-5 rounded-lg flex items-center">
                             <Flag className="mr-2 h-5 w-5" />
                             Reportes de Productos
                         </button>
                     </Link>
                     <Link href="/administration/report/comments">
-                        <button className="bg-red-100 hover:bg-red-200 text-red-800 py-3 px-5 rounded-lg flex items-center">
+                        <button className="w-full sm:w-auto bg-red-100 hover:bg-red-200 text-red-800 py-3 px-5 rounded-lg flex items-center">
                             <Flag className="mr-2 h-5 w-5" />
                             Reportes de Comentarios
                         </button>
                     </Link>
                 </div>
-            </div>
+            </section>
 
             {/* Sección de Configuración */}
-            <div className="mb-10">
-                <h2 className="text-xl font-bold mb-4 flex items-center">
+            <section className="mb-10 bg-white/80 rounded-xl shadow p-4 md:p-6">
+                <h2 className="text-xl font-semibold mb-4 flex items-center border-b pb-2">
                     <Settings className="mr-2 h-6 w-6 text-purple-600" />
                     Configuración
                 </h2>
-                <div className="flex flex-wrap gap-3">
+                <div className="flex flex-col sm:flex-row flex-wrap gap-3">
                     <Link href="/administration/settings">
-                        <button className="bg-purple-600 hover:bg-purple-700 text-white py-3 px-5 rounded-lg flex items-center">
+                        <button className="w-full sm:w-auto bg-purple-600 hover:bg-purple-700 text-white py-3 px-5 rounded-lg flex items-center">
                             <Settings className="mr-2 h-5 w-5" />
                             Configuraciones Generales
                         </button>
                     </Link>
                     <Link href="/administration/settings/banner">
-                        <button className="bg-purple-100 hover:bg-purple-200 text-purple-800 py-3 px-5 rounded-lg flex items-center">
+                        <button className="w-full sm:w-auto bg-purple-100 hover:bg-purple-200 text-purple-800 py-3 px-5 rounded-lg flex items-center">
                             <Bell className="mr-2 h-5 w-5" />
                             Gestión de Banners
                         </button>
                     </Link>
                     <Link href="/administration/sponsors">
-                        <button className="bg-purple-100 hover:bg-purple-200 text-purple-800 py-3 px-5 rounded-lg flex items-center">
+                        <button className="w-full sm:w-auto bg-purple-100 hover:bg-purple-200 text-purple-800 py-3 px-5 rounded-lg flex items-center">
                             <Bell className="mr-2 h-5 w-5" />
                             Auspiciantes
                         </button>
                     </Link>
                     <Link href="/administration/notifications">
-                        <button className="bg-purple-100 hover:bg-purple-200 text-purple-800 py-3 px-5 rounded-lg flex items-center">
+                        <button className="w-full sm:w-auto bg-purple-100 hover:bg-purple-200 text-purple-800 py-3 px-5 rounded-lg flex items-center">
                             <Bell className="mr-2 h-5 w-5" />
                             Notificaciones
                         </button>
                     </Link>
                     <Link href="/administration/crowfunding">
-                        <button className="bg-purple-100 hover:bg-purple-200 text-purple-800 py-3 px-5 rounded-lg flex items-center">
+                        <button className="w-full sm:w-auto bg-purple-100 hover:bg-purple-200 text-purple-800 py-3 px-5 rounded-lg flex items-center">
                             <Bell className="mr-2 h-5 w-5" />
                             Colectas
                         </button>
                     </Link>
                 </div>
-            </div>
+            </section>
 
             {/* Sección de Usuarios */}
-            <div className="mb-10">
-                <h2 className="text-xl font-bold mb-4 flex items-center">
+            <section className="mb-10 bg-white/80 rounded-xl shadow p-4 md:p-6">
+                <h2 className="text-xl font-semibold mb-4 flex items-center border-b pb-2">
                     <Users className="mr-2 h-6 w-6 text-amber-600" />
                     Gestión de Usuarios
                 </h2>
-                <div className="flex flex-wrap gap-3">
+                <div className="flex flex-col sm:flex-row flex-wrap gap-3">
                     <Link href="/administration/users">
-                        <button className="bg-amber-600 hover:bg-amber-700 text-white py-3 px-5 rounded-lg flex items-center">
+                        <button className="w-full sm:w-auto bg-amber-600 hover:bg-amber-700 text-white py-3 px-5 rounded-lg flex items-center">
                             <Users className="mr-2 h-5 w-5" />
                             Todos los Usuarios
                         </button>
                     </Link>
                     <Link href="/administration/users/regular">
-                        <button className="bg-amber-100 hover:bg-amber-200 text-amber-800 py-3 px-5 rounded-lg flex items-center">
+                        <button className="w-full sm:w-auto bg-amber-100 hover:bg-amber-200 text-amber-800 py-3 px-5 rounded-lg flex items-center">
                             <Users className="mr-2 h-5 w-5" />
                             Usuarios Regulares
                         </button>
                     </Link>
                     <Link href="/administration/users/organizations">
-                        <button className="bg-amber-100 hover:bg-amber-200 text-amber-800 py-3 px-5 rounded-lg flex items-center">
+                        <button className="w-full sm:w-auto bg-amber-100 hover:bg-amber-200 text-amber-800 py-3 px-5 rounded-lg flex items-center">
                             <Users className="mr-2 h-5 w-5" />
                             Organizaciones
                         </button>
                     </Link>
                     <Link href="/administration/users/admins">
-                        <button className="bg-amber-100 hover:bg-amber-200 text-amber-800 py-3 px-5 rounded-lg flex items-center">
+                        <button className="w-full sm:w-auto bg-amber-100 hover:bg-amber-200 text-amber-800 py-3 px-5 rounded-lg flex items-center">
                             <Users className="mr-2 h-5 w-5" />
                             Administradores
                         </button>
                     </Link>
                 </div>
-            </div>
-
+            </section>
         </div>
     );
 }

--- a/components/navbar-admin.tsx
+++ b/components/navbar-admin.tsx
@@ -9,6 +9,8 @@ import {
   Flag,
   Settings,
   Users,
+  Menu as MenuIcon,
+  X as CloseIcon,
 } from "lucide-react";
 
 const navbarAdminItems = [
@@ -62,6 +64,7 @@ export default function NavbarAdmin() {
   const [openIndex, setOpenIndex] = useState<number | null>(null);
   const [dropdownPosition, setDropdownPosition] = useState({ top: 0, left: 0 });
   const buttonRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const [openAccordion, setOpenAccordion] = useState<number | null>(null);
 
   const handleClick = (path: string) => {
     router.push(path);
@@ -119,24 +122,69 @@ export default function NavbarAdmin() {
           }
         }
       }
-    }; document.addEventListener('mousedown', handleClickOutside);
+    };
+    document.addEventListener('mousedown', handleClickOutside);
     return () => {
       document.removeEventListener('mousedown', handleClickOutside);
     };
   }, [openIndex]);
 
+  useEffect(() => {
+    setOpenIndex(null);
+  }, [pathname]);
+
   return (
-    <nav className="flex items-center gap-2 md:gap-4 overflow-x-auto pb-2 w-full md:pb-0 md:justify-center">
-      {navbarAdminItems.map((item, index) =>
-        item.isDropdown ? (
+    <nav className="w-full bg-white shadow px-2 py-2 relative z-20 flex flex-col">
+      <div className="flex items-center w-full justify-between">
+        <div className="flex items-center">
+        </div>
+        <div className="flex items-center gap-2">
+        </div>
+      </div>
+      <div className="flex flex-col gap-2 sm:hidden mt-2">
+        {navbarAdminItems.map((item, index) => (
+          <div key={index} className="border rounded-lg overflow-hidden">
+            <button
+              onClick={() => setOpenAccordion(openAccordion === index ? null : index)}
+              className={`w-full flex items-center justify-between px-4 py-2 text-base font-medium bg-white hover:bg-purple-50 transition-colors ${openAccordion === index ? 'text-purple-600' : 'text-gray-700'}`}
+            >
+              <span className="flex items-center">{item.icon}{item.name}</span>
+              <ChevronDown className={`ml-2 h-4 w-4 transition-transform ${openAccordion === index ? 'rotate-180' : ''}`} />
+            </button>
+            {openAccordion === index && (
+              <div className="flex flex-col bg-white border-t">
+                {item.items.map((subItem: any) => (
+                  <button
+                    key={subItem.path}
+                    onClick={() => {
+                      handleClick(subItem.path);
+                      setOpenAccordion(null);
+                    }}
+                    className={`w-full text-left px-6 py-2 text-sm hover:bg-gray-50 ${isActiveMenuItem(subItem.path)
+                      ? 'bg-purple-50 text-purple-600'
+                      : 'text-gray-700'
+                    }`}
+                  >
+                    {subItem.name}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+      <div
+        className="hidden sm:flex sm:flex-row sm:gap-4 sm:justify-center sm:w-full mt-2"
+      >
+        {navbarAdminItems.map((item, index) => (
           <div key={index} className="relative">
             <button
               ref={el => { buttonRefs.current[index] = el; }}
               onClick={() => toggleDropdown(index)}
-              className={`flex items-center text-base font-medium px-3 py-2 rounded-lg hover:bg-purple-100 hover:text-purple-600 transition-colors ${isActiveRoute(item)
-                  ? "bg-purple-100 text-purple-600"
-                  : "text-gray-700"
-                }`}
+              className={`flex items-center text-base font-medium px-3 py-2 rounded-lg hover:bg-purple-100 hover:text-purple-600 transition-colors w-full sm:w-auto ${isActiveRoute(item)
+                ? "bg-purple-100 text-purple-600"
+                : "text-gray-700"
+              }`}
               aria-expanded={openIndex === index}
               aria-haspopup="true"
               type="button"
@@ -144,18 +192,12 @@ export default function NavbarAdmin() {
               {item.icon}
               {item.name}
               <ChevronDown
-                className={`ml-1 h-4 w-4 transition-transform ${openIndex === index ? "rotate-180" : ""
-                  }`}
+                className={`ml-1 h-4 w-4 transition-transform ${openIndex === index ? "rotate-180" : ""}`}
               />
             </button>
-
             {openIndex === index && (
               <div
-                className="fixed z-50 w-60 bg-white rounded-md shadow-lg border border-gray-200"
-                style={{
-                  top: `${dropdownPosition.top}px`,
-                  left: `${dropdownPosition.left}px`,
-                }}
+                className={`z-50 w-60 bg-white rounded-md shadow-lg border border-gray-200 mt-1 absolute left-0 top-full`}
                 role="menu"
               >
                 {item.items.map((subItem: any) => (
@@ -164,10 +206,11 @@ export default function NavbarAdmin() {
                     onClick={() => {
                       handleClick(subItem.path);
                       setOpenIndex(null);
-                    }} className={`block w-full text-left px-4 py-2 text-sm hover:bg-gray-50 ${isActiveMenuItem(subItem.path)
-                        ? "bg-purple-50 text-purple-600"
-                        : "text-gray-700"
-                      }`}
+                    }}
+                    className={`block w-full text-left px-4 py-2 text-sm hover:bg-gray-50 ${isActiveMenuItem(subItem.path)
+                      ? "bg-purple-50 text-purple-600"
+                      : "text-gray-700"
+                    }`}
                     role="menuitem"
                   >
                     {subItem.name}
@@ -176,20 +219,8 @@ export default function NavbarAdmin() {
               </div>
             )}
           </div>
-        ) : (
-          <button
-            key={item.path}
-            onClick={() => handleClick(item.path || "")}
-            className={`flex items-center text-base font-medium px-3 py-2 rounded-lg hover:bg-purple-100 hover:text-purple-600 transition-colors ${isActiveRoute(item)
-                ? "bg-purple-100 text-purple-600"
-                : "text-gray-700"
-              }`}
-          >
-            {item.icon}
-            {item.name}
-          </button>
-        )
-      )}
+        ))}
+      </div>
     </nav>
   );
 }


### PR DESCRIPTION
Ahora el navbar de administración funciona así:
En móvil:
Cada sección principal del menú es un acordeón clásico: solo una sección puede estar abierta a la vez.
Al tocar una sección, se despliegan sus subopciones; al tocar otra, se cierra la anterior.
El menú horizontal y los dropdowns quedan ocultos.
En desktop:
El menú sigue siendo horizontal y con dropdowns como antes, perfectamente centrado.
app/(pages)/(content)/administration/page.tsx (Panel principal de administración)
Mejora estética y responsiva del panel:
El contenido ahora está centrado y limitado en ancho con max-w-7xl mx-auto.
Secciones con fondo blanco translúcido, bordes redondeados y sombra para mayor claridad y separación visual.
Títulos de sección más grandes, con borde inferior y tipografía semibold.
Botones responsivos: ocupan todo el ancho en móvil y solo el necesario en desktop.
